### PR TITLE
Fix palette not  written;  'error: 1:expected value' (Ubuntu 15.04/Gnome 3.14)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -100,7 +100,7 @@ set_profile_colors() {
     then local profile_path=$dconfdir/$profile
 
     # set color palette
-    dconf write $profile_path/palette "[$(cat $dir/$COLOR/palette)]"
+    dconf write $profile_path/palette "['$(cat $dir/$COLOR/palette)']"
 
     # set foreground, background and highlight color
     dconf write $profile_path/bold-color "'$(cat $bd_color_file)'"


### PR DESCRIPTION
## Justification

This _very minor_ fix ensures we don't see the error output shown here when running `install.sh` [output below truncated for clarity):

```
$ ./install.sh 

This script will ask you which Gnome Terminal profile to overwrite.

[... preamble, profile selection menu, confirmation etc. ...]

Confirmation received -- applying settings
error: 1:expected value

Usage:
  dconf write KEY VALUE 

[...]
```

After this error is observed, we can do `dconf list /org/gnome/terminal/legacy/profiles:/${profileid}/` and no 'palette' key will be available.   With the fix in this pull request the error is avoided and a palette key is written by dconf.
