### PR TITLE
updating missing link in readme to the repository

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -6,7 +6,7 @@ Scripts for setting the Monokai color set with Gnome Terminal.
 Installation and usage
 ----------------------
 
-Clone the [git repository], then run `./install.sh`.
+Clone the [git repository](https://github.com/pricco/gnome-terminal-colors-monokai.git), then run `./install.sh`.
 
     $ git clone git://github.com/pricco/gnome-terminal-colors-monokai.git
     $ cd gnome-terminal-colors-monokai


### PR DESCRIPTION
thanks for setting this repo up, the installation script works like a charm!  I read the `[git repository]` and assumed it was intended to be a link, but the alternative would be to just remove the brackets, the url is listed in the walkthrough right below :)
